### PR TITLE
C inteface for the TVToolBox

### DIFF
--- a/TVToolBoxCInterface.hs
+++ b/TVToolBoxCInterface.hs
@@ -5,15 +5,15 @@ import TVToolBox
 import Foreign.C.Types
 
 --Compute Jensen-Shannon divergence given bin,TV,Count and lookahead values.
-sqrtJsdC :: Integer -> MyFloat -> Integer -> Integer -> Integer -> MyFloat -> Integer -> Integer -> MyFloat
-sqrtJsdC b1 s1 c1 k1 b2 s2 c2 k2 = sqrtJsd d1 d2
-	where d1 = discretize b1 (genDist s1 c1 k1)
-              d2 = discretize b2 (genDist s2 c2 k2)
+sqrtJsdC :: Integer -> MyFloat -> Integer -> Integer -> MyFloat -> Integer -> Integer -> MyFloat
+sqrtJsdC b1 s1 c1 b2 s2 c2 k = sqrtJsd d1 d2
+	where d1 = discretize b1 (genDist s1 c1 k)
+              d2 = discretize b2 (genDist s2 c2 k)
 
-sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CInt -> CDouble -> CInt -> CInt ->CDouble 
-sqrtJsdC_hs  b1 s1 c1 k1 b2 s2 c2 k2 = realToFrac $ sqrtJsdC (fromIntegral b1) (realToFrac s1)
-                                       (fromIntegral c1) (fromIntegral k1) (fromIntegral b2)
-                                       (realToFrac s2) (fromIntegral c2) (fromIntegral k2)
+sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CDouble -> CInt -> CInt -> CDouble 
+sqrtJsdC_hs  b1 s1 c1 b2 s2 c2 k = realToFrac $ sqrtJsdC (fromIntegral b1) (realToFrac s1)
+                                       (fromIntegral c1) (fromIntegral b2)
+                                       (realToFrac s2) (fromIntegral c2) (fromIntegral k)
 
-foreign export ccall sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CInt -> CDouble -> CInt -> CInt ->CDouble 
+foreign export ccall sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CDouble -> CInt -> CInt -> CDouble 
 

--- a/TVToolBoxCInterface.hs
+++ b/TVToolBoxCInterface.hs
@@ -1,0 +1,19 @@
+module TVToolBoxCIntegererface where
+
+import TVToolBox
+
+import Foreign.C.Types
+
+--Compute Jensen-Shannon divergence given bin,TV,Count and lookahead values.
+sqrtJsdC :: Integer -> MyFloat -> Integer -> Integer -> Integer -> MyFloat -> Integer -> Integer -> MyFloat
+sqrtJsdC b1 s1 c1 k1 b2 s2 c2 k2 = sqrtJsd d1 d2
+	where d1 = discretize b1 (genDist s1 c1 k1)
+              d2 = discretize b2 (genDist s2 c2 k2)
+
+sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CInt -> CDouble -> CInt -> CInt ->CDouble 
+sqrtJsdC_hs  b1 s1 c1 k1 b2 s2 c2 k2 = realToFrac $ sqrtJsdC (fromIntegral b1) (realToFrac s1)
+                                       (fromIntegral c1) (fromIntegral k1) (fromIntegral b2)
+                                       (realToFrac s2) (fromIntegral c2) (fromIntegral k2)
+
+foreign export ccall sqrtJsdC_hs :: CInt -> CDouble -> CInt -> CInt -> CInt -> CDouble -> CInt -> CInt ->CDouble 
+


### PR DESCRIPTION
This is not meant to be the right way to design the interface considering the function expects eight arguments. but, it fulfills the purpose of calculating MI between two atoms from a C++ code in a simplistic way.
